### PR TITLE
Ignore rule in tt

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -44,8 +44,16 @@
     },
     "whitelist": {
       "whitelistConfigPaths": [
-        "./allow.yml",
+        "./allow.yml"
       ]
+    },
+    "node-types": {
+      // reviewプラグインでは、tt命令はTeletypeとしてパースされる。
+      // TeletypeはNodeタイプが'Inline'としてtextlint本体に解釈される。
+      // 参考
+      // https://github.com/orangain/textlint-plugin-review/blob/7d660f45a6a81a3456059ed7dfc598df253a2ca8/src/inline-parsers.js#L32
+      // https://github.com/orangain/textlint-plugin-review/blob/7d660f45a6a81a3456059ed7dfc598df253a2ca8/src/mapping.js#L49
+      "nodeTypes": ["Inline"]
     }
   }
 }

--- a/articles/budougumi0617.re
+++ b/articles/budougumi0617.re
@@ -8,3 +8,6 @@
 それならばGo言語。
 
 始めてみようGo言語。
+
+@<code>{git commit --amend}はエラーにしてほしくない。（デフォルトで無視される）
+@<tt>{git commit --amend}はエラーにしてほしくない。

--- a/package-lock.json
+++ b/package-lock.json
@@ -3679,6 +3679,11 @@
       "resolved": "https://registry.npmjs.org/textlint-filter-rule-comments/-/textlint-filter-rule-comments-1.2.2.tgz",
       "integrity": "sha1-OnLElJlOBo4OSqrQ8k6nz+M4UDo="
     },
+    "textlint-filter-rule-node-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-filter-rule-node-types/-/textlint-filter-rule-node-types-1.0.1.tgz",
+      "integrity": "sha1-124sXxcpuo53u/E4dID1UtvLZwI="
+    },
     "textlint-filter-rule-whitelist": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/textlint-filter-rule-whitelist/-/textlint-filter-rule-whitelist-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prh": "^5.4.4",
     "textlint": "^11.3.1",
     "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-filter-rule-node-types": "^1.0.1",
     "textlint-filter-rule-whitelist": "^2.0.0",
     "textlint-plugin-review": "^0.3.3",
     "textlint-rule-max-ten": "^2.0.3",


### PR DESCRIPTION
# PRの概要
(見てほしい点などこのPRの要点を書いてください)
こちらの対応で `tt`に囲まれたワードは無視するようにしました。
https://github.com/golangtokyo/shoten8/pull/3#discussion_r368215778

# PDFを確認する
textlintとredpenによるルールチェックをクリアするとPDFが生成され、PRに保存場所が通知されます。

